### PR TITLE
Oasis restore correct amount of canteen uses

### DIFF
--- a/vimel.py
+++ b/vimel.py
@@ -65,7 +65,7 @@ while not done: # Main loop
             print ("You drink, fill up your canteen and your Vimel rests.")
             thirst = 0
             camel_tiredness = 0
-            canteen = 5
+            canteen = 3
             print ()
             
         else:
@@ -88,7 +88,7 @@ while not done: # Main loop
             print ("You drink, fill up your canteen and your camel rests.")
             thirst = 0
             camel_tiredness = 0
-            canteen = 5
+            canteen = 3
             print ()
             
         else:


### PR DESCRIPTION
Fixed a mistake that would set the canteen to 5 instead of the standard 3 at an oasis.